### PR TITLE
[Update]新規登録失敗画面でのリロード実行後の遷移先追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   scope module: :public do
     root to: "homes#top"
     devise_for :users
-
+    get "users" => redirect("/users/sign_up")
     get 'searches/search'
     resources :posts do
       resource :favorite, only: [:create, :destroy]


### PR DESCRIPTION
## 新規登録失敗画面でのリロード実行後の遷移先設定
*再度新規登録画面に戻るようルーティングを追加