### PR TITLE
Fix/sign up layout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  def devise_error_messages
+    return "" if resource.errors.empty?
+    html = ""
+    messages = resource.errors.full_messages.each do |msg|
+      html += <<-EOF
+        <div>
+          <li class="error_msg">#{msg}</li>
+         </div>
+      EOF
+    end
+    html.html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,20 @@
 module ApplicationHelper
+
   def devise_error_messages
     return "" if resource.errors.empty?
     html = ""
-    messages = resource.errors.full_messages.each do |msg|
-      html += <<-EOF
-        <div>
-          <li class="error_msg">#{msg}</li>
-         </div>
-      EOF
+
+    messages_order = ['name', 'email', 'password', ]
+    
+    messages_order.each do |field|
+      error_messages = resource.errors.full_messages_for(field)
+      error_messages.each do |msg|
+        html += <<-EOF
+          <div>
+            <li style="color: #930403;">#{msg}</li>
+           </div>
+        EOF
+      end
     end
     html.html_safe
   end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -8,6 +8,9 @@
   color: #930403;
 }
 
+.field_with_errors {
+  width: 85%;
+}
 
 p {
   line-height: 15px;

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -17,7 +17,7 @@
             </div>
             <%= f.text_field :name, autofocus: true, autocomplete: "email", class: "form-control", placeholder: "名前" %>
           </div>
-
+    
           <div class="input-group mb-3">
             <div class="input-group-prepend">
               <span class="input-group-text" aria-hidden="true"><i class="fa-regular fa-envelope"></i></span>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,4 +1,5 @@
-<%= render "devise/shared/error_messages", resource: resource %>
+
+<%= devise_error_messages %>
 <div class="container">
   <div class="row no-gutters">
     <div class="col-md-6 col-sm-10 mx-sm-auto border rounded" >

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Hitokuchi
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
+    
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
## 新規登録失敗時のフォームサイズの変更・新規登録失敗時のエラーメッセージの色統一
* 登録失敗時にfield_with_errorsクラスの自動生成により、フォームが崩れていたためcssに修正を記述
* エラーメッセージの色を他のエラーと統一