### PR TITLE
[Fix]投稿文字数を超えた場合のエラーメッセージを日本語化

### DIFF
--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -32,6 +32,7 @@ ja:
               blank: "を入力してください"  
             body:
               blank: "を入力してください"
+              too_long: "は50文字以内で入力してください"
     attributes:
       post:
         body: "コメント"


### PR DESCRIPTION
## エラーメッセージの日本語化
* 投稿文字数が50文字を超えた場合のエラーメッセージを日本語で設定