### PR TITLE
[Fix]自己紹介の文字数が超えた場合のエラーメッセージを日本語化

### DIFF
--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -24,6 +24,8 @@ ja:
               too_long: "は%{count}文字以下に設定して下さい。"
               invalid: "は有効でありません。"
               confirmation: "が内容とあっていません。"  
+            introduction:
+              too_long: "は50文字以内で入力してください"
         post:
           attributes:
             image:
@@ -42,6 +44,7 @@ ja:
         current_password: "現在のパスワード"
         name: 名前
         email: "メールアドレス"
+        introduction: "自己紹介"
         password: "パスワード"
         password_confirmation: "確認用パスワード"
         remember_me: "次回から自動的にログイン"


### PR DESCRIPTION
## エラーメッセージをの日本語化
* 自己紹介文字数が50文字を超えた場合のエラーメッセージを日本語化